### PR TITLE
added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.ipynb_checkpoints
+**/*~
+**/*.list 
+**/*.p


### PR DESCRIPTION
@sbuschbach @dtomc @rmazumdar I added a .gitignore file to prevent us from accidentally committing files that should not be committed, such as: 
1) .ipynb_checkpoints 
2) *~ files 
3) files that end in .list (all our .list files are too big to push)
4) pickle files (I expect these to be enormous too)
